### PR TITLE
(bugfix) made cut work with mono sounds

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -83,7 +83,7 @@
 
 			var uberSegment = null;
 
-			if (!force && wavesurfer.SelectedChannelsLen === 1)
+			if (!force && wavesurfer.SelectedChannelsLen < originalBuffer.numberOfChannels)
 			{
 				uberSegment = wavesurfer.backend.ac.createBuffer (
 					originalBuffer.numberOfChannels,


### PR DESCRIPTION
When working with a mono sound, cutting doesn't remove the selected range. This PR should fix it.

**Steps to reproduce the bug:**
1. Load the sample file.
2. Click Edit > Channel Info/Flip > Make Mono > Apply Changes.
3. Select a portion of the sound.
4. Click the cut icon.

**Expected result**
The selected range is removed.

**Actual result**
The selected range is replaced with a silence.