### PR TITLE
(bugfix) use the correct sample rate for recording

### DIFF
--- a/src/fx-pg-eq.js
+++ b/src/fx-pg-eq.js
@@ -2949,6 +2949,7 @@
 						btn_add.style.display = 'none';
 
 						audio_context = new (window.AudioContext || window.webkitAudioContext)();
+						sample_rate = audio_context.sampleRate;
 
 						var audio_val = true;
 						if (has_devices) {


### PR DESCRIPTION
The current code incorrectly assumes that the sample rate is 44,100 Hz. When the user creates a new recording on a system with the sample rate of 16,000 Hz, this creates a high-pitched sound.

(h/t @lgelauff for finding this bug.)