### PR TITLE
(bugfix) fixed waveform rendering when view scrolls

### DIFF
--- a/src/dist/wavesurfer.js
+++ b/src/dist/wavesurfer.js
@@ -5831,6 +5831,8 @@ var WebAudio = function (_util$Observer) {
                      //   if (abs_shift > 0.5) {
                         shift = Math.round ( shift );
 
+                        first = this.peaksStart - (shift * sampleSize);
+
                         shift = (shift * 2);
                         //    shift = Math.round ( Math.abs (shift) ) * (shift < 0 ? - 1 : 1);
 


### PR DESCRIPTION
The bug in #11 is caused by the waveform being rendered incorrectly when the view scrolls. When the view scrolls, `getPeaks()` in wavesurfer.js calculates the shift in the view in pixels, round it to the nearest integer, moves the data in the buffer accordingly, and only calculates the peaks in the newly visible region. The rounding causes some small error. However, the error adds up as the view moves continuously and causes a discrepancy between the playhead position and the waveform.

This PR fixes #11 by making it as if the view scrolled by the amount that made the shift an integer without rounding.