### PR TITLE
A11y fixes

### DIFF
--- a/src/about.html
+++ b/src/about.html
@@ -104,13 +104,13 @@
 <h1>Introducing AudioMass (<a href="https://audiomass.co" target="_blank">https://audiomass.co</a>) an open-source web based audio and waveform editing tool.</h1>
 
 
-<img class="top" src="/about/audiomass_top.jpg" />
+<img class="top" src="/about/audiomass_top.jpg" alt="Screenshot of AudioMass with parametric EQ options visible" />
 
 
 <p>AudioMass lets you record, or use your existing audio tracks, and modify them by trimming, cutting, pasting or applying a plethora of effects, from compression and paragraphic equalizers to reverb, delay and distortion fx. AudioMass also supports more than 20 hotkeys combinations and a dynamic responsive interface to ensure ease of use and that your producivity remains high.
 it is written solely in plain old-school javascript, weights approximately 65kb and has no backend or framework dependencies.</p>
 
-<img class="mid" src="/about/audiomass_support.jpg" />
+<img class="mid" src="/about/audiomass_support.jpg" alt="AudioMass shown running on multiple devices" />
 <p>It also has very good browser and device support.</p>
 
 
@@ -146,21 +146,21 @@ it is written solely in plain old-school javascript, weights approximately 65kb 
 <p>To get started, drag and drop an audio file, or try the included sample.<br />
 Once the file is loaded and you can view the waveform, zoom in, pan around, or select a region.</p>
 
-<img class="mid" src="/about/audiomass_2.jpg" />
+<img class="mid" src="/about/audiomass_2.jpg" alt="Screenshot of selected audio" />
 
 
 <h3>Recording Audio</h3>
 
 <p>To record audio, simply press the Recording button, or the <i>[R]</i> key.</p>
 
-<img class="mid" src="/about/audiomass_3.jpg" />
+<img class="mid" src="/about/audiomass_3.jpg" alt="Screenshot of recording in progress" />
 
 
 <h3>Exporting to mp3</h3>
 
 <p>In order to export back to mp3, click on 'File', then 'Export to mp3', and follow the modal's instructions.</p>
 
-<img class="mid" src="/about/audiomass_4.jpg" />
+<img class="mid" src="/about/audiomass_4.jpg" alt="Export MP3 screenshot" />
 
 </div>
 
@@ -177,11 +177,11 @@ It started as a personal small tool for quick visualization of waveforms. Later 
 <p>In general I am a big fan of the interfaces of DAWs <i>(Digital Audio Workstations)</i>, they are extremely, complex, intricate, versatile, and they manage to remain visually pleasant even through their infinite options and knobs. Many times I feel the web has taken a very wrong turn, as amazing interfaces such as...
 
 <p class="nomarg">Sonar</p>
-<img class="mid" src="/about/sonar.jpg" />
+<img class="mid" src="/about/sonar.jpg" alt="Sonar screenshot" />
 
 <br />
 <p class="nomarg">Fruity loops</p>
-<img class="mid" src="/about/fruity.png" />
+<img class="mid" src="/about/fruity.png" alt="Fruity loops screenshot" />
 
 <br />
 

--- a/src/fx-pg-eq.js
+++ b/src/fx-pg-eq.js
@@ -1615,8 +1615,10 @@
 				};
 				if (!PKAudioEditor.engine.wavesurfer.isReady)
 				{
-					play_btn.className += ' pk_inact';
-					both_btn.className += ' pk_inact';
+					// play_btn.className += ' pk_inact';
+					_setButtonState(play_btn,'inactive');
+					// both_btn.className += ' pk_inact';
+					_setButtonState(both_btn,'inactive');
 				}
 
 				if (PKAudioEditor.engine.wavesurfer.isPlaying()) {
@@ -1865,8 +1867,10 @@
 
 				if (!PKAudioEditor.engine.wavesurfer.isReady)
 				{
-					play_btn.className += ' pk_inact';
-					loop_btn.className += ' pk_inact';
+					// play_btn.className += ' pk_inact';
+					_setButtonState(play_btn,'inactive');
+					// loop_btn.className += ' pk_inact';
+					_setButtonState(loop_btn,'inactive');
 				}
 				if (PKAudioEditor.engine.wavesurfer.isPlaying()) {
 					play_btn.className += ' pk_act';
@@ -2877,14 +2881,16 @@
 							  }
 
 							  is_ready = true;
-							  btn_start.classList.remove ('pk_inact');
+									// btn_start.classList.remove ('pk_inact');
+									_setButtonState(btn_start,'active');
 							});
 						}
 						else {
 							devices_sel.parentNode.style.display = 'none';
 							has_devices = false;
 							is_ready = true;
-							btn_start.classList.remove ('pk_inact');
+							// btn_start.classList.remove ('pk_inact');
+							_setButtonState(btn_start,'active');
 						}
 					};
 
@@ -2934,7 +2940,8 @@
 						if (is_active) {
 							stop ();
 
-							btn_pause.classList.add ('pk_inact');
+							// btn_pause.classList.add ('pk_inact');
+							_setButtonState(btn_pause,'inactive');
 							btn_start.innerText = 'START RECORDING';
 
 							return ;
@@ -2969,7 +2976,8 @@
 			            	script_processor.connect ( audio_context.destination );
 
 			            	is_active = true;
-			            	btn_pause.classList.remove ('pk_inact');
+																// btn_pause.classList.remove ('pk_inact');
+																_setButtonState(btn_pause,'active');
 			            	btn_start.innerText = 'FINISH RECORDING';
 			            	script_processor.onaudioprocess = fetchBufferFunction;
 

--- a/src/index-cache.html
+++ b/src/index-cache.html
@@ -32,7 +32,7 @@
 
 <a href="#skipToolbar" class="skip">Skip to main toolbar</a>
 
-	<div id="app"></div>
+	<div id="app" role="application"></div>
 
 	<script src="dist/wavesurfer.js"></script>
 	<script src="dist/plugin/wavesurfer.regions.js"></script>

--- a/src/index-cache.html
+++ b/src/index-cache.html
@@ -29,6 +29,9 @@
 	<link rel="stylesheet" type="text/css" href="main.css">
 </head>
 <body>
+
+<a href="#skipToolbar" class="skip">Skip to main toolbar</a>
+
 	<div id="app"></div>
 
 	<script src="dist/wavesurfer.js"></script>

--- a/src/index-cache.html
+++ b/src/index-cache.html
@@ -5,7 +5,7 @@
 	<link href="ico.png" rel="shortcut icon">
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
 
 	<meta name="description" content="AudioMass is a free full-featured web-based audio &amp; waveform editing tool"/>
 	<meta property="og:image" content="https://audiomass.co/icon.jpg"/>

--- a/src/index.html
+++ b/src/index.html
@@ -30,6 +30,9 @@
 	<link rel="stylesheet" type="text/css" href="main.css">
 </head>
 <body>
+
+<a href="#skipToolbar" class="skip">Skip to main toolbar</a>
+
 	<div id="app"></div>
 
 	<script src="dist/wavesurfer.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -33,7 +33,7 @@
 
 <a href="#skipToolbar" class="skip">Skip to main toolbar</a>
 
-	<div id="app"></div>
+	<div id="app" role="application"></div>
 
 	<script src="dist/wavesurfer.js"></script>
 	<script src="dist/plugin/wavesurfer.regions.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
 	<link href="ico.png" rel="shortcut icon">
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0"/>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0"/>
 
 	<meta name="description" content="AudioMass is a free full-featured web-based audio &amp; waveform editing tool"/>
 	<meta property="og:image" content="https://audiomass.co/icon.jpg"/>

--- a/src/main.css
+++ b/src/main.css
@@ -73,7 +73,8 @@ body,html{height:100%;background:#111;
 	white-space:nowrap
 }
 
-.pk_hdr .pk_btn:hover{
+.pk_hdr .pk_btn:hover,
+.pk_hdr .pk_btn:focus-within{
 	background:#eee;
 	color:#111
 }
@@ -630,7 +631,7 @@ a{cursor:pointer;color:#99c2c6;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 	box-shadow: 0 2px 12px rgba(138, 58, 138, 0.5);
 	background-clip: padding-box;
 }
-.pk_contextMenu a, .pk_contextMenu a:hover{
+.pk_contextMenu a, .pk_contextMenu a:hover, .pk_contextMenu a:focus{
 	clear: both;
 	color: #eee;
 	display: block;
@@ -645,7 +646,8 @@ a{cursor:pointer;color:#99c2c6;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 	font-weight:normal;
 	transition: all 110ms;
 }
-.pk_contextMenu a:hover{
+.pk_contextMenu a:hover,
+.pk_contextMenu a:focus{
 	color:#99c2c6;
 	line-height: 18px;
 	text-decoration: none;
@@ -936,7 +938,8 @@ a{cursor:pointer;color:#99c2c6;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 	-webkit-user-select:none;
 	user-select:none;
 }
-.pk_modal_a_bottom:hover{
+.pk_modal_a_bottom:hover,
+.pk_modal_a_bottom:focus{
 	/*background: #eee;
     color: #111;
     border-color: #eee;*/
@@ -958,7 +961,8 @@ a{cursor:pointer;color:#99c2c6;-webkit-tap-highlight-color:rgba(0,0,0,0)}
     transition: background 120ms;
 }
 
-.pk_modal_cancel:hover{
+.pk_modal_cancel:hover,
+.pk_modal_cancel:focus{
 	box-shadow: 0 0 6px rgba(158, 39, 39, 0.6);
     border-color: unset;
     background: #280a0ac7;
@@ -970,7 +974,8 @@ a{cursor:pointer;color:#99c2c6;-webkit-tap-highlight-color:rgba(0,0,0,0)}
     transition: border-color 120ms, color 120ms;
 }
 
-.pk_modal_a_accpt:hover{
+.pk_modal_a_accpt:hover,
+.pk_modal_a_accpt:focus{
     color: #99c2c6;
 }
 
@@ -1153,7 +1158,8 @@ a{cursor:pointer;color:#99c2c6;-webkit-tap-highlight-color:rgba(0,0,0,0)}
     letter-spacing: normal;
 }
 
-.pk_sel_edt:hover > span{
+.pk_sel_edt:hover > span,
+.pk_sel_edt:focus > span{
 	visibility:visible;
 	opacity: 1;
 }
@@ -1666,7 +1672,8 @@ input.pk_horiz.pk_w180{
     transition:background 120ms;
 }
 
-.pk_pgeq_els:hover{
+.pk_pgeq_els:hover,
+.pk_pgeq_els:focus{
 	background:#3b413f;
 }
 
@@ -1821,7 +1828,8 @@ body.pk_stndln{
 	background:#303030;
 }
 
-.pk_tbsa:hover{
+.pk_tbsa:hover,
+.pk_tbsa:focus{
 	box-shadow: inset 0 -2px 6px #181818;
 }
 
@@ -1894,7 +1902,8 @@ body.pk_stndln{
     transition: background 70ms;
 }
 
-#pk_tmp_tap3:hover{
+#pk_tmp_tap3:hover,
+#pk_tmp_tap3:focus{
 	background:#363636;
 }
 
@@ -1930,7 +1939,8 @@ body.pk_stndln{
     padding-right:5px;
 }
 
-.pk_lcldrf:hover{
+.pk_lcldrf:hover,
+.pk_lcldrf:focus{
 	background:#292929;
 }
 
@@ -1986,4 +1996,18 @@ body.pk_stndln{
 .pk_aut_act,
 .pk_aut{
     box-shadow: 0px 0px 20px #eee, inset 0px 0px 4px gold;
+}
+
+/* a11y fixes */
+* .pk_btn,
+.pk_pan_btn:focus {
+	border:3px solid #333;
+	transition-duration: 0.2s;
+}
+* .pk_btn:focus,
+.pk_pan_btn:focus {
+	border:3px solid black;
+	color:black;
+	background: white;
+	box-shadow: 0 0 0 2px #fff;
 }

--- a/src/main.css
+++ b/src/main.css
@@ -1999,9 +1999,7 @@ body.pk_stndln{
 }
 
 /* a11y fixes */
-* .pk_btn,
-.pk_pan_btn:focus {
-	border:3px solid #333;
+* .pk_btn{	
 	transition-duration: 0.2s;
 }
 * .pk_btn:focus,

--- a/src/main.css
+++ b/src/main.css
@@ -1999,7 +1999,39 @@ body.pk_stndln{
 }
 
 /* a11y fixes */
-* .pk_btn{	
+
+/*for skip links*/
+.skip {
+	height: 1px;
+	overflow: hidden;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+	left:-10px;
+}
+a.skip:focus {
+	clip: none;
+	height: auto;
+	overflow: none;
+	width: auto;
+	background: black;
+	color:white;
+	font-weight: bold;
+	font-size: 22px;
+	padding: 10px;
+	z-index: 1000;
+	top: 30px;
+	left: 15px;
+	border: 2px solid white;
+	border-radius: 3px;
+	outline: none;
+}
+#skipToolbar:focus {
+	outline: 2px solid white;
+}
+
+* .pk_btn, .pk_pan_btn {	
+	cursor: pointer;
 	transition-duration: 0.2s;
 }
 * .pk_btn:focus,

--- a/src/modal.js
+++ b/src/modal.js
@@ -24,6 +24,9 @@
 		// var centerer
 		var el_cont = d.createElement ('div');
 		el_cont.className = 'pk_modal_cnt';
+		el_cont.setAttribute('role','dialog');
+		el_cont.setAttribute('aria-labelledby','dialogHeading');
+		el_cont.setAttribute('aria-describedby','dialogContent');
 		this.el_cont = el_cont;
 		
 		// title

--- a/src/modal.js
+++ b/src/modal.js
@@ -25,6 +25,7 @@
 		var el_cont = d.createElement ('div');
 		el_cont.className = 'pk_modal_cnt';
 		el_cont.setAttribute('role','dialog');
+		el_cont.setAttribute('aria-modal','true');
 		el_cont.setAttribute('aria-labelledby','dialogHeading');
 		el_cont.setAttribute('aria-describedby','dialogContent');
 		this.el_cont = el_cont;

--- a/src/ui.js
+++ b/src/ui.js
@@ -1672,8 +1672,6 @@
 
 		var btn_panner_left = d.createElement ('button');
 		var btn_panner_right = d.createElement ('button');
-		btn_panner_left.setAttribute ('tabIndex', -1);
-		btn_panner_right.setAttribute ('tabIndex', -1);
 		btn_panner_left.className = 'pk_pan_btn';
 		btn_panner_right.className = 'pk_pan_btn';
 
@@ -1728,7 +1726,6 @@
 		var btn_zoom_in_h = d.createElement ('button');
 		btn_zoom_in_h.className = 'pk_btn pk_zoom_in_h';
 		btn_zoom_in_h.innerHTML = '+<span>Zoom In Horiz (+)</span>';
-		btn_zoom_in_h.setAttribute ('tabIndex', -1);
 		btn_zoom_in_h.onclick = function () {
 			app.fireEvent ('RequestZoomUI', 'h', -1);
 			this.blur();
@@ -1737,7 +1734,6 @@
 		var btn_zoom_out_h = d.createElement ('button');
 		btn_zoom_out_h.className = 'pk_btn pk_zoom_out_h pk_inact';
 		btn_zoom_out_h.innerHTML = '&ndash;<span>Zoom Out Horiz (-)</span>';
-		btn_zoom_out_h.setAttribute ('tabIndex', -1);
 		btn_zoom_out_h.onclick = function () {
 			app.fireEvent ('RequestZoomUI', 'h', 1);
 			this.blur();
@@ -1746,7 +1742,6 @@
 		var btn_zoom_reset = d.createElement ('button');
 		btn_zoom_reset.className = 'pk_btn pk_zoom_reset pk_inact';
 		btn_zoom_reset.innerHTML = '[R] <span>Reset Zoom (0)</span>';
-		btn_zoom_reset.setAttribute ('tabIndex', -1);
 		btn_zoom_reset.onclick = function () {
 			app.fireEvent ('RequestZoomUI', 0);
 			this.blur();
@@ -1768,7 +1763,6 @@
 		var btn_zoom_in_v = d.createElement ('button');
 		btn_zoom_in_v.className = 'pk_btn pk_zoom_in_v';
 		btn_zoom_in_v.innerHTML = '&#x2195; +<span>Zoom In Vertically</span>';
-		btn_zoom_in_v.setAttribute ('tabIndex', -1);
 		btn_zoom_in_v.onclick = function () {
 			app.fireEvent ('RequestZoomUI', 'v', -1);
 			this.blur();
@@ -1777,7 +1771,6 @@
 		var btn_zoom_out_v = d.createElement ('button');
 		btn_zoom_out_v.className = 'pk_btn pk_zoom_out_v';
 		btn_zoom_out_v.innerHTML = '&#x2195; &ndash;<span>Zoom Out Vertically</span>';
-		btn_zoom_out_v.setAttribute ('tabIndex', -1);
 		btn_zoom_out_v.onclick = function () {
 			app.fireEvent ('RequestZoomUI', 'v', 1);
 			this.blur();
@@ -2067,7 +2060,6 @@
 
 		// play button
 		var btn_stop = d.createElement ('button');
-		btn_stop.setAttribute ('tabIndex', -1);
 		btn_stop.innerHTML = '<span>Stop Playback (Space)</span>';
 		btn_stop.className = 'pk_btn pk_stop icon-stop2';
 		btn_stop.onclick = function() {
@@ -2076,7 +2068,6 @@
 		transport.appendChild ( btn_stop );
 
 		var btn_play = d.createElement ('button');
-		btn_play.setAttribute ('tabIndex', -1);
 		btn_play.className = 'pk_btn pk_play icon-play3';
 		btn_play.innerHTML = '<span>Play (Space)</span>';
 		transport.appendChild ( btn_play );
@@ -2092,7 +2083,6 @@
 		});
 
 		var btn_pause = d.createElement ('button');
-		btn_pause.setAttribute('tabIndex', -1);
 		btn_pause.className = 'pk_btn pk_pause icon-pause2';
 		btn_pause.innerHTML = '<span>Pause (Shift+Space)</span>';
 		transport.appendChild ( btn_pause );
@@ -2102,7 +2092,6 @@
 		};
 
 		var btn_loop = d.createElement ('button');
-		btn_loop.setAttribute('tabIndex', -1);
 		btn_loop.className = 'pk_btn pk_loop icon-loop';
 		btn_loop.innerHTML = '<span>Toggle Loop (L)</span>';
 		transport.appendChild ( btn_loop );
@@ -2116,7 +2105,6 @@
 		});
 
 		var btn_back_jump = d.createElement ('button');
-		btn_back_jump.setAttribute('tabIndex', -1);
 		btn_back_jump.className = 'pk_btn pk_back_jump icon-backward2';
 		btn_back_jump.innerHTML = '<span>Seek (left arrow)</span>';
 		transport.appendChild ( btn_back_jump );
@@ -2196,7 +2184,6 @@
 		////////////////////////
 
 		var btn_front_jump = d.createElement ('button');
-		btn_front_jump.setAttribute('tabIndex', -1);
 		btn_front_jump.className = 'pk_btn pk_front_jump icon-forward3';
 		btn_front_jump.innerHTML = '<span>Seek (right arrow)</span>';
 		transport.appendChild ( btn_front_jump );
@@ -2388,7 +2375,6 @@
 		}, [27]);
 
 		var btn_back_total = d.createElement ('button');
-		btn_back_total.setAttribute('tabIndex', -1);
 		btn_back_total.className = 'pk_btn icon-previous2';
 		btn_back_total.innerHTML = '<span>Seek Start (Shift + left arrow)</span>';
 		transport.appendChild ( btn_back_total );
@@ -2399,7 +2385,6 @@
 		};
 
 		var btn_front_total = d.createElement ('button');
-		btn_front_total.setAttribute('tabIndex', -1);
 		btn_front_total.className = 'pk_btn icon-next2';
 		btn_front_total.innerHTML = '<span>Seek End (Shift + right arrow)</span>';
 		btn_front_total.onclick = function() {
@@ -2411,7 +2396,6 @@
 
 
 		var btn_rec = d.createElement ('button');
-		btn_rec.setAttribute('tabIndex', -1);
 		btn_rec.className = 'pk_btn icon-rec';
 		btn_rec.innerHTML = '<span>Record (R)</span>';
 		btn_rec.onclick = function() {
@@ -2684,7 +2668,6 @@
 		actions.className = 'pk_ctns';
 		
 		var copy_btn = d.createElement ('button');
-		copy_btn.setAttribute('tabIndex', -1);
 		copy_btn.className = 'pk_btn icon-files-empty pk_inact';
 		copy_btn.innerHTML = '<span>Copy Selection (Shift + C)</span>';
 		actions.appendChild ( copy_btn );
@@ -2713,7 +2696,6 @@
 		};
 
 		var cut_btn = d.createElement ('button');
-		cut_btn.setAttribute('tabIndex', -1);
 		cut_btn.className = 'pk_btn icon-scissors pk_inact';
 		cut_btn.innerHTML = '<span>Cut Selection (Shift + X)</span>';
 		actions.appendChild ( cut_btn );
@@ -2724,7 +2706,6 @@
 		};
 		
 		var silence_btn = d.createElement ('button');
-		silence_btn.setAttribute('tabIndex', -1);
 		silence_btn.className = 'pk_btn icon-silence';
 		silence_btn.innerHTML = '<span>Insert Silence (Shift + N)</span>';
 		actions.appendChild ( silence_btn );
@@ -2752,7 +2733,6 @@
 		'</div>';
 		
 		var btn_clear_selection = d.createElement ('button');
-		btn_clear_selection.setAttribute('tabIndex', -1);
 		btn_clear_selection.className = 'pk_btn icon-clearsel pk_inact';
 		btn_clear_selection.innerHTML = '<span>Clear Selection (~ tilda)</span>';
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -2060,7 +2060,8 @@
 
 		// play button
 		var btn_stop = d.createElement ('button');
-		btn_stop.innerHTML = '<span>Stop Playback (Space)</span>';
+		btn_stop.innerHTML = '<span id="btn_stop_label">Stop Playback (Space)</span>';
+		btn_stop.setAttribute('aria-labelledby','btn_stop_label');
 		btn_stop.className = 'pk_btn pk_stop icon-stop2';
 		btn_stop.onclick = function() {
 			UI.fireEvent('RequestStop');
@@ -2069,7 +2070,8 @@
 
 		var btn_play = d.createElement ('button');
 		btn_play.className = 'pk_btn pk_play icon-play3';
-		btn_play.innerHTML = '<span>Play (Space)</span>';
+		btn_play.innerHTML = '<span id="btn_play_label">Play (Space)</span>';
+		btn_play.setAttribute('aria-labelledby','btn_play_label');
 		transport.appendChild ( btn_play );
 		btn_play.onclick = function() {
 			UI.fireEvent('RequestPlay');
@@ -2084,7 +2086,8 @@
 
 		var btn_pause = d.createElement ('button');
 		btn_pause.className = 'pk_btn pk_pause icon-pause2';
-		btn_pause.innerHTML = '<span>Pause (Shift+Space)</span>';
+		btn_pause.innerHTML = '<span id="btn_pause_label">Pause (Shift+Space)</span>';
+		btn_pause.setAttribute('aria-labelledby','btn_pause_label');
 		transport.appendChild ( btn_pause );
 		btn_pause.onclick = function() {
 			UI.fireEvent('RequestPause');
@@ -2093,7 +2096,8 @@
 
 		var btn_loop = d.createElement ('button');
 		btn_loop.className = 'pk_btn pk_loop icon-loop';
-		btn_loop.innerHTML = '<span>Toggle Loop (L)</span>';
+		btn_loop.innerHTML = '<span id="btn_loop_label">Toggle Loop (L)</span>';
+		btn_loop.setAttribute('aria-labelledby','btn_loop_label');
 		transport.appendChild ( btn_loop );
 		btn_loop.onclick = function() {
 			UI.fireEvent('RequestSetLoop');
@@ -2106,7 +2110,8 @@
 
 		var btn_back_jump = d.createElement ('button');
 		btn_back_jump.className = 'pk_btn pk_back_jump icon-backward2';
-		btn_back_jump.innerHTML = '<span>Seek (left arrow)</span>';
+		btn_back_jump.innerHTML = '<span id="btn_back_jump_label">Seek (left arrow)</span>';
+		btn_back_jump.setAttribute('aria-labelledby','btn_back_jump_label');
 		transport.appendChild ( btn_back_jump );
 
 		///////////////////////////////////////////////////////////
@@ -2185,7 +2190,8 @@
 
 		var btn_front_jump = d.createElement ('button');
 		btn_front_jump.className = 'pk_btn pk_front_jump icon-forward3';
-		btn_front_jump.innerHTML = '<span>Seek (right arrow)</span>';
+		btn_front_jump.innerHTML = '<span id="btn_front_jump_label">Seek (right arrow)</span>';
+		btn_front_jump.setAttribute('aria-labelledby','btn_front_jump_label');
 		transport.appendChild ( btn_front_jump );
 
 		var btn_frnt_focus = false;
@@ -2376,7 +2382,8 @@
 
 		var btn_back_total = d.createElement ('button');
 		btn_back_total.className = 'pk_btn icon-previous2';
-		btn_back_total.innerHTML = '<span>Seek Start (Shift + left arrow)</span>';
+		btn_back_total.innerHTML = '<span id="btn_back_total_label">Seek Start (Shift + left arrow)</span>';
+		btn_back_total.setAttribute('aria-labelledby','btn_back_total_label');
 		transport.appendChild ( btn_back_total );
 		btn_back_total.onclick = function() {
 			UI.fireEvent( 'RequestRegionClear');
@@ -2386,7 +2393,8 @@
 
 		var btn_front_total = d.createElement ('button');
 		btn_front_total.className = 'pk_btn icon-next2';
-		btn_front_total.innerHTML = '<span>Seek End (Shift + right arrow)</span>';
+		btn_front_total.innerHTML = '<span id="btn_front_total_label">Seek End (Shift + right arrow)</span>';
+		btn_front_total.setAttribute('aria-labelledby','btn_front_total_label');
 		btn_front_total.onclick = function() {
 			UI.fireEvent( 'RequestRegionClear');
 			UI.fireEvent( 'RequestSeekTo', 0.996);
@@ -2397,7 +2405,8 @@
 
 		var btn_rec = d.createElement ('button');
 		btn_rec.className = 'pk_btn icon-rec';
-		btn_rec.innerHTML = '<span>Record (R)</span>';
+		btn_rec.innerHTML = '<span id="btn_rec_label">Record (R)</span>';
+		btn_rec.setAttribute('aria-labelledby','btn_rec_label');
 		btn_rec.onclick = function() {
 			if (this.getAttribute('disabled') === 'disabled') {
 				this.blur (); return ;
@@ -2669,7 +2678,8 @@
 		
 		var copy_btn = d.createElement ('button');
 		copy_btn.className = 'pk_btn icon-files-empty pk_inact';
-		copy_btn.innerHTML = '<span>Copy Selection (Shift + C)</span>';
+		copy_btn.innerHTML = '<span id="copy_btn_label">Copy Selection (Shift + C)</span>';
+		copy_btn.setAttribute('aria-labelledby','copy_btn_label');
 		actions.appendChild ( copy_btn );
 
 		copy_btn.onclick = function() {
@@ -2687,7 +2697,8 @@
 		var paste_btn = d.createElement ('button');
 		paste_btn.setAttribute('focusable', 'false');
 		paste_btn.className = 'pk_btn icon-file-text2 pk_inact';
-		paste_btn.innerHTML = '<span>Paste Selection (Shift + V)</span>';
+		paste_btn.innerHTML = '<span id="paste_btn_label">Paste Selection (Shift + V)</span>';
+		paste_btn.setAttribute('aria-labelledby','paste_btn_label');
 		actions.appendChild ( paste_btn );
 
 		paste_btn.onclick = function() {
@@ -2697,7 +2708,8 @@
 
 		var cut_btn = d.createElement ('button');
 		cut_btn.className = 'pk_btn icon-scissors pk_inact';
-		cut_btn.innerHTML = '<span>Cut Selection (Shift + X)</span>';
+		cut_btn.innerHTML = '<span id="cut_btn_label">Cut Selection (Shift + X)</span>';
+		cut_btn.setAttribute('aria-labelledby','cut_btn_label');
 		actions.appendChild ( cut_btn );
 
 		cut_btn.onclick = function() {
@@ -2707,7 +2719,8 @@
 		
 		var silence_btn = d.createElement ('button');
 		silence_btn.className = 'pk_btn icon-silence';
-		silence_btn.innerHTML = '<span>Insert Silence (Shift + N)</span>';
+		silence_btn.innerHTML = '<span id="silence_btn_label">Insert Silence (Shift + N)</span>';
+		silence_btn.setAttribute('aria-labelledby','silence_btn_label');
 		actions.appendChild ( silence_btn );
 		
 		UI.KeyHandler.addCallback ('KeyShiftN', function( k ) {
@@ -2734,7 +2747,8 @@
 		
 		var btn_clear_selection = d.createElement ('button');
 		btn_clear_selection.className = 'pk_btn icon-clearsel pk_inact';
-		btn_clear_selection.innerHTML = '<span>Clear Selection (~ tilda)</span>';
+		btn_clear_selection.innerHTML = '<span id="btn_clear_selection_label">Clear Selection (~ tilda)</span>';
+		btn_clear_selection.setAttribute('aria-labelledby','btn_clear_selection_label');
 
 		var sel_spans = selection.getElementsByClassName('pk_dat');
 		UI.listenFor ('DidCreateRegion', function ( region ) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -2687,8 +2687,8 @@
 		
 		var actions = d.createElement( 'div' );
 		actions.className = 'pk_ctns';
-		action.setAttribute('role','group');
-		action.setAttribute('aria-label','Copy/Paste controls');
+		actions.setAttribute('role','group');
+		actions.setAttribute('aria-label','Copy/Paste controls');
 		
 		var copy_btn = d.createElement ('button');
 		copy_btn.className = 'pk_btn icon-files-empty pk_inact';

--- a/src/ui.js
+++ b/src/ui.js
@@ -1291,6 +1291,8 @@
 	function _makeUITopHeader ( menu_tree, UI ) {
 		var header = d.createElement ( 'div' );
 		header.className = 'pk_hdr pk_noselect';
+		header.setAttribute('role','region');
+		header.setAttribute('aria-label','Application menu');
 
 		var _name = 'TopHeader',
 			_default_class = 'pk_btn pk_noselect';
@@ -1648,6 +1650,8 @@
 
 		var audio_container = d.createElement ('div');
 		audio_container.className = 'pk_av_cont';
+		audio_container.setAttribute('role','region');
+		audio_container.setAttribute('aria-label','Audio waveform');
 		UI.el.appendChild( audio_container );
 
 
@@ -1659,6 +1663,8 @@
 		
 		var footer = d.createElement ( 'div' );
 		footer.className = 'pk_ftr pk_noselect';
+		footer.setAttribute('role','region');
+		footer.setAttribute('aria-label','Volume information');
 		UI.el.appendChild( footer );
 
 		// make panner buttons
@@ -2048,6 +2054,8 @@
 	function _makeUIToolbar (UI) {
 		var container = d.createElement ( 'div' );
 		container.className = 'pk_tbc';
+		container.setAttribute('role','toolbar');
+		container.setAttribute('aria-label','Main tools');
 
 		var toolbar = d.createElement ( 'div' );
 		toolbar.className = 'pk_tb pk_noselect';
@@ -2057,6 +2065,8 @@
 		
 		var transport = d.createElement( 'div' );
 		transport.className = 'pk_transport';
+		transport.setAttribute('role','group');
+		transport.setAttribute('aria-label','Transport controls');
 
 		// play button
 		var btn_stop = d.createElement ('button');
@@ -2442,6 +2452,8 @@
 
 		var timing = d.createElement( 'div' );
 		timing.className = 'pk_timecontainer';
+		timing.setAttribute('role','group');
+		timing.setAttribute('aria-label','Time information')
 
 		var timingspan = d.createElement( 'span' );
 		timingspan.innerText = '00:00:000';
@@ -2675,6 +2687,8 @@
 		
 		var actions = d.createElement( 'div' );
 		actions.className = 'pk_ctns';
+		action.setAttribute('role','group');
+		action.setAttribute('aria-label','Copy/Paste controls');
 		
 		var copy_btn = d.createElement ('button');
 		copy_btn.className = 'pk_btn icon-files-empty pk_inact';
@@ -2738,6 +2752,8 @@
 		
 		var selection = d.createElement( 'div' );
 		selection.className = 'pk_selection';
+		selection.setAttribute('role','group');
+		selection.setAttribute('aria-label','Selected audio time properties');
 		selection.innerHTML = '<div class="pk_sellist">' + 
 			'<span class="pk_title">Selection:</span>' + 
 			'<div><span class="title">Start:</span><span class="s_s pk_dat">-</span></div>' + 

--- a/src/ui.js
+++ b/src/ui.js
@@ -2723,7 +2723,8 @@
 		};
 
 		var cut_btn = d.createElement ('button');
-		cut_btn.className = 'pk_btn icon-scissors pk_inact';
+		cut_btn.className = 'pk_btn icon-scissors';
+		_setButtonActiveState(cut_btn,'inactive');
 		cut_btn.innerHTML = '<span>Cut Selection (Shift + X)</span>';
 		cut_btn.setAttribute('aria-label','Cut Selection (Shift + X)');
 		actions.appendChild ( cut_btn );
@@ -2841,6 +2842,18 @@
 
 		// -
 	};
+
+	function _setButtonActiveState(button,state) {
+		if (state==="active") {
+			button.removeAttribute('tabindex');
+			button.classList.remove('pk_inact');
+		} else {
+			button.setAttribute('tabindex','-1');
+			button.classList.add('pk_inact');
+		}
+	}
+
+
 
 	function _makeMobileScroll (UI) {
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -2059,7 +2059,7 @@
 
 		var toolbar = d.createElement ( 'div' );
 		toolbar.className = 'pk_tb pk_noselect';
-		toolbar.setAttribute('tabindex','0');
+		toolbar.setAttribute('tabindex','-1');
 		toolbar.setAttribute('id','skipToolbar');
 
 		var btn_groups = d.createElement( 'div' );

--- a/src/ui.js
+++ b/src/ui.js
@@ -2022,9 +2022,9 @@
 		// change temp message, it's pretty ugly #### TODO
 		var ttmp = d.createElement('div');
 		ttmp.className = 'pk_tmpMsg';
-		ttmp.innerHTML = 'Drag n drop an Audio File in this window, or click ' +
-		'<a style="white-space:nowrap;border:1px solid;border-radius:23px;padding:5px 18px;font-size:0.94em;margin-left:5px" '+
-		'onclick="PKAudioEditor.engine.LoadSample()">here to use a sample</a>';
+		ttmp.innerHTML = 'Drag n drop an Audio File in this window, or ' +
+		'<a href="#" style="white-space:nowrap;border:1px solid;border-radius:23px;padding:5px 18px;font-size:0.94em;margin-left:5px" '+
+		'onclick="PKAudioEditor.engine.LoadSample()">load a sample audio file</a>';
 		main_audio_view.appendChild( ttmp );
 
 		var ttmp2 = d.createElement('div');

--- a/src/ui.js
+++ b/src/ui.js
@@ -2054,8 +2054,8 @@
 	function _makeUIToolbar (UI) {
 		var container = d.createElement ( 'div' );
 		container.className = 'pk_tbc';
-		container.setAttribute('role','toolbar');
-		container.setAttribute('aria-label','Main tools');
+		container.setAttribute('role','region');
+		container.setAttribute('aria-label','Main toolbar');
 
 		var toolbar = d.createElement ( 'div' );
 		toolbar.className = 'pk_tb pk_noselect';
@@ -2070,8 +2070,8 @@
 
 		// play button
 		var btn_stop = d.createElement ('button');
-		btn_stop.innerHTML = '<span id="btn_stop_label">Stop Playback (Space)</span>';
-		btn_stop.setAttribute('aria-labelledby','btn_stop_label');
+		btn_stop.innerHTML = '<span>Stop Playback (Space)</span>';
+		btn_stop.setAttribute('aria-label','Stop Playback (Space)');
 		btn_stop.className = 'pk_btn pk_stop icon-stop2';
 		btn_stop.onclick = function() {
 			UI.fireEvent('RequestStop');
@@ -2080,8 +2080,8 @@
 
 		var btn_play = d.createElement ('button');
 		btn_play.className = 'pk_btn pk_play icon-play3';
-		btn_play.innerHTML = '<span id="btn_play_label">Play (Space)</span>';
-		btn_play.setAttribute('aria-labelledby','btn_play_label');
+		btn_play.innerHTML = '<span>Play (Space)</span>';
+		btn_play.setAttribute('aria-label','Play (Space)');
 		transport.appendChild ( btn_play );
 		btn_play.onclick = function() {
 			UI.fireEvent('RequestPlay');
@@ -2096,8 +2096,8 @@
 
 		var btn_pause = d.createElement ('button');
 		btn_pause.className = 'pk_btn pk_pause icon-pause2';
-		btn_pause.innerHTML = '<span id="btn_pause_label">Pause (Shift+Space)</span>';
-		btn_pause.setAttribute('aria-labelledby','btn_pause_label');
+		btn_pause.innerHTML = '<span>Pause (Shift+Space)</span>';
+		btn_pause.setAttribute('aria-label','Pause (Shift+Space)');
 		transport.appendChild ( btn_pause );
 		btn_pause.onclick = function() {
 			UI.fireEvent('RequestPause');
@@ -2106,8 +2106,8 @@
 
 		var btn_loop = d.createElement ('button');
 		btn_loop.className = 'pk_btn pk_loop icon-loop';
-		btn_loop.innerHTML = '<span id="btn_loop_label">Toggle Loop (L)</span>';
-		btn_loop.setAttribute('aria-labelledby','btn_loop_label');
+		btn_loop.innerHTML = '<span>Toggle Loop (L)</span>';
+		btn_loop.setAttribute('aria-label','Toggle Loop (L)');
 		transport.appendChild ( btn_loop );
 		btn_loop.onclick = function() {
 			UI.fireEvent('RequestSetLoop');
@@ -2120,8 +2120,8 @@
 
 		var btn_back_jump = d.createElement ('button');
 		btn_back_jump.className = 'pk_btn pk_back_jump icon-backward2';
-		btn_back_jump.innerHTML = '<span id="btn_back_jump_label">Seek (left arrow)</span>';
-		btn_back_jump.setAttribute('aria-labelledby','btn_back_jump_label');
+		btn_back_jump.innerHTML = '<span>Seek (left arrow)</span>';
+		btn_back_jump.setAttribute('aria-label','Seek (left arrow)');
 		transport.appendChild ( btn_back_jump );
 
 		///////////////////////////////////////////////////////////
@@ -2200,8 +2200,8 @@
 
 		var btn_front_jump = d.createElement ('button');
 		btn_front_jump.className = 'pk_btn pk_front_jump icon-forward3';
-		btn_front_jump.innerHTML = '<span id="btn_front_jump_label">Seek (right arrow)</span>';
-		btn_front_jump.setAttribute('aria-labelledby','btn_front_jump_label');
+		btn_front_jump.innerHTML = '<span>Seek (right arrow)</span>';
+		btn_front_jump.setAttribute('aria-label','Seek (right arrow)');
 		transport.appendChild ( btn_front_jump );
 
 		var btn_frnt_focus = false;
@@ -2392,8 +2392,8 @@
 
 		var btn_back_total = d.createElement ('button');
 		btn_back_total.className = 'pk_btn icon-previous2';
-		btn_back_total.innerHTML = '<span id="btn_back_total_label">Seek Start (Shift + left arrow)</span>';
-		btn_back_total.setAttribute('aria-labelledby','btn_back_total_label');
+		btn_back_total.innerHTML = '<span>Seek Start (Shift + left arrow)</span>';
+		btn_back_total.setAttribute('aria-label','Seek Start (Shift + left arrow)');
 		transport.appendChild ( btn_back_total );
 		btn_back_total.onclick = function() {
 			UI.fireEvent( 'RequestRegionClear');
@@ -2403,8 +2403,8 @@
 
 		var btn_front_total = d.createElement ('button');
 		btn_front_total.className = 'pk_btn icon-next2';
-		btn_front_total.innerHTML = '<span id="btn_front_total_label">Seek End (Shift + right arrow)</span>';
-		btn_front_total.setAttribute('aria-labelledby','btn_front_total_label');
+		btn_front_total.innerHTML = '<span>Seek End (Shift + right arrow)</span>';
+		btn_front_total.setAttribute('aria-label','Seek End (Shift + right arrow)');
 		btn_front_total.onclick = function() {
 			UI.fireEvent( 'RequestRegionClear');
 			UI.fireEvent( 'RequestSeekTo', 0.996);
@@ -2415,8 +2415,8 @@
 
 		var btn_rec = d.createElement ('button');
 		btn_rec.className = 'pk_btn icon-rec';
-		btn_rec.innerHTML = '<span id="btn_rec_label">Record (R)</span>';
-		btn_rec.setAttribute('aria-labelledby','btn_rec_label');
+		btn_rec.innerHTML = '<span>Record (R)</span>';
+		btn_rec.setAttribute('aria-label','Record (R)');
 		btn_rec.onclick = function() {
 			if (this.getAttribute('disabled') === 'disabled') {
 				this.blur (); return ;
@@ -2692,8 +2692,8 @@
 		
 		var copy_btn = d.createElement ('button');
 		copy_btn.className = 'pk_btn icon-files-empty pk_inact';
-		copy_btn.innerHTML = '<span id="copy_btn_label">Copy Selection (Shift + C)</span>';
-		copy_btn.setAttribute('aria-labelledby','copy_btn_label');
+		copy_btn.innerHTML = '<span>Copy Selection (Shift + C)</span>';
+		copy_btn.setAttribute('aria-label','Copy Selection (Shift + C)');
 		actions.appendChild ( copy_btn );
 
 		copy_btn.onclick = function() {
@@ -2711,8 +2711,8 @@
 		var paste_btn = d.createElement ('button');
 		paste_btn.setAttribute('focusable', 'false');
 		paste_btn.className = 'pk_btn icon-file-text2 pk_inact';
-		paste_btn.innerHTML = '<span id="paste_btn_label">Paste Selection (Shift + V)</span>';
-		paste_btn.setAttribute('aria-labelledby','paste_btn_label');
+		paste_btn.innerHTML = '<span>Paste Selection (Shift + V)</span>';
+		paste_btn.setAttribute('aria-label','Paste Selection (Shift + V)');
 		actions.appendChild ( paste_btn );
 
 		paste_btn.onclick = function() {
@@ -2722,8 +2722,8 @@
 
 		var cut_btn = d.createElement ('button');
 		cut_btn.className = 'pk_btn icon-scissors pk_inact';
-		cut_btn.innerHTML = '<span id="cut_btn_label">Cut Selection (Shift + X)</span>';
-		cut_btn.setAttribute('aria-labelledby','cut_btn_label');
+		cut_btn.innerHTML = '<span>Cut Selection (Shift + X)</span>';
+		cut_btn.setAttribute('aria-label','Cut Selection (Shift + X)');
 		actions.appendChild ( cut_btn );
 
 		cut_btn.onclick = function() {
@@ -2733,8 +2733,8 @@
 		
 		var silence_btn = d.createElement ('button');
 		silence_btn.className = 'pk_btn icon-silence';
-		silence_btn.innerHTML = '<span id="silence_btn_label">Insert Silence (Shift + N)</span>';
-		silence_btn.setAttribute('aria-labelledby','silence_btn_label');
+		silence_btn.innerHTML = '<span>Insert Silence (Shift + N)</span>';
+		silence_btn.setAttribute('aria-label','Insert Silence (Shift + N)');
 		actions.appendChild ( silence_btn );
 		
 		UI.KeyHandler.addCallback ('KeyShiftN', function( k ) {
@@ -2763,8 +2763,8 @@
 		
 		var btn_clear_selection = d.createElement ('button');
 		btn_clear_selection.className = 'pk_btn icon-clearsel pk_inact';
-		btn_clear_selection.innerHTML = '<span id="btn_clear_selection_label">Clear Selection (~ tilda)</span>';
-		btn_clear_selection.setAttribute('aria-labelledby','btn_clear_selection_label');
+		btn_clear_selection.innerHTML = '<span>Clear Selection (~ tilda)</span>';
+		btn_clear_selection.setAttribute('aria-label','Clear Selection (~ tilda)');
 
 		var sel_spans = selection.getElementsByClassName('pk_dat');
 		UI.listenFor ('DidCreateRegion', function ( region ) {

--- a/src/ui.js
+++ b/src/ui.js
@@ -2059,6 +2059,8 @@
 
 		var toolbar = d.createElement ( 'div' );
 		toolbar.className = 'pk_tb pk_noselect';
+		toolbar.setAttribute('tabindex','0');
+		toolbar.setAttribute('id','skipToolbar');
 
 		var btn_groups = d.createElement( 'div' );
 		btn_groups.className = 'pk_btngroup';

--- a/src/welcome.js
+++ b/src/welcome.js
@@ -20,12 +20,12 @@ setTimeout(function () {
 
 			// Welcome to AudioMass,
 			var md = new PKSimpleModal({
-				title: '<font style="font-size:15px">Welcome to AudioMass</font>',
+				title: '<font id="dialogHeading" role="heading" aria-level="1" style="font-size:15px">Welcome to AudioMass</font>',
 				ondestroy: function( q ) {
 					PKAE.ui.InteractionHandler.on = false;
 					PKAE.ui.KeyHandler.removeCallback ('modalTemp');
 			},
-			body:'<div style="overflow:auto;-webkit-overflow-scrolling:touch;max-width:580px;width:calc(100vw - 40px);max-height:calc(100vh - 340px);min-height:110px;font-size:13px; color:#95c6c6;padding-top:7px;">'+
+			body:'<div id="dialogContent" style="overflow:auto;-webkit-overflow-scrolling:touch;max-width:580px;width:calc(100vw - 40px);max-height:calc(100vh - 340px);min-height:110px;font-size:13px; color:#95c6c6;padding-top:7px;">'+
 				'AudioMass is a free, open source, web-based Audio and Waveform Editor.<br />It runs entirely in the browser with no backend and no plugins required!'+
 				'<br/><br/><br/>'+
 				body_str+

--- a/src/welcome.js
+++ b/src/welcome.js
@@ -10,7 +10,7 @@ setTimeout(function () {
 			if (PKAE.isMobile) {
 				change -= 15;
 				body_str = 'Tips:<br/>Please make sure your device is not in silent mode. You might need to physically flip the silent switch. '+
-				'<img src="phone-switch.jpg" style="max-width:224px;max-height:126px;width:40%;margin: 10px auto; display: block;"/>'+
+				'<img src="phone-switch.jpg" alt="Phone silent mode switch" style="max-width:224px;max-height:126px;width:40%;margin: 10px auto; display: block;"/>'+
 				'<br/><br/>';
 			}
 			else {

--- a/src/welcome.js
+++ b/src/welcome.js
@@ -15,7 +15,7 @@ setTimeout(function () {
 			}
 			else {
 				body_str = 'Tips:<br/>Please keep in mind that most key shortcuts rely on the <strong>Shift + <u>key</u></strong> combo. (eg Shift+Z for undo, Shift+C copy, Shift+X cut... etc )<br/><br/>';
-				body_str2 = 'Check out the codebase on <a href="https://github.com/pkalogiros/audiomass" target="_blank">Github</a><br/><br/>'; // checkout the code on github
+				body_str2 = '<a href="https://github.com/pkalogiros/audiomass" target="_blank">Check out the codebase on Github</a><br/><br/>'; // checkout the code on github
 			}
 
 			// Welcome to AudioMass,
@@ -52,7 +52,9 @@ setTimeout(function () {
 				}
 			});
 			md.Show ();
+
 			document.getElementsByClassName('pk_modal_cancel')[0].innerHTML = '&nbsp; &nbsp; &nbsp; OK &nbsp; &nbsp; &nbsp;';
+			document.getElementsByClassName('pk_modal_cancel')[0].focus();
 	};
 
 	var change = 96;


### PR DESCRIPTION
As per https://github.com/pkalogiros/AudioMass/issues/35

A number of accessibility fixes for AudioMass :)

Summary:

* Made all buttons keyboard-accessible
* Added region and group roles
* Removed maximum-scale restriction to allow users to zoom
* Made 'load sample' link accessible
* Added focus styles for all main controls
* Added a skip link to main toolbar that appears on keyboard focus
* Added alt attributes for all images

See attachments for some before/after comparisons:

Before:
<img width="377" alt="ARC 1 before" src="https://user-images.githubusercontent.com/2778763/87985729-fbd26000-cad3-11ea-8e87-9d736e4757a2.png">
After:
<img width="374" alt="ARC 2 after" src="https://user-images.githubusercontent.com/2778763/87985733-fd038d00-cad3-11ea-852f-57d78af6fe07.png">
Before:
<img width="499" alt="AXE 1 before" src="https://user-images.githubusercontent.com/2778763/87985735-fe34ba00-cad3-11ea-8e15-deeb1456d5fb.png">
After:
<img width="502" alt="AXE 2 after" src="https://user-images.githubusercontent.com/2778763/87985738-fecd5080-cad3-11ea-864a-b0a4a5e01f3e.png">
Before:
<img width="540" alt="Lighthouse 1 before" src="https://user-images.githubusercontent.com/2778763/87985741-ff65e700-cad3-11ea-9941-cf4958304728.png">
After:
<img width="534" alt="Lighthouse 2 after" src="https://user-images.githubusercontent.com/2778763/87985742-ff65e700-cad3-11ea-9c1a-9ffda32114e3.png">


