### PR TITLE
Change checked MIME type for .wav files to the correct audio/wav

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -148,7 +148,7 @@
 			if (e.files.length > 0)
 			{
 				if (e.files[0].type == "audio/mp3"
-					|| e.files[0].type == "audio/wave"
+					|| e.files[0].type == "audio/wav"
 					|| e.files[0].type == "audio/mpeg"
 					|| e.files[0].type == "audio/aiff"
 					|| e.files[0].type == "audio/flac"


### PR DESCRIPTION
Fixes the issue of being unable to load `.wav` files via "Load from Computer"