### PR TITLE
refactor: migrate server script from Python 2 to Python 3

### DIFF
--- a/src/audiomass-server.py
+++ b/src/audiomass-server.py
@@ -1,7 +1,9 @@
-import SimpleHTTPServer
-import SocketServer
-PORT = 5055 
-Handler = SimpleHTTPServer.SimpleHTTPRequestHandler
-httpd = SocketServer.TCPServer(("", PORT), Handler)
-print "serving at port", PORT
-httpd.serve_forever()
+import http.server
+import socketserver
+
+PORT = 5055
+Handler = http.server.SimpleHTTPRequestHandler
+
+with socketserver.TCPServer(("", PORT), Handler) as httpd:
+    print("serving at port", PORT)
+    httpd.serve_forever()


### PR DESCRIPTION
Hi friends, since Python 2 is no longer maintained and most people are now using Python 3, I've updated the startup script's syntax from Python 2 to Python 3. If you approve, please merge it. Thanks!